### PR TITLE
fix(build): update GoReleaser config to resolve deprecation warnings

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,10 +38,10 @@ builds:
     binary: "{{ .ProjectName }}_v{{ .Version }}"
 
 archives:
-  - format: tar.gz
+  - formats: ["tar.gz"]
     format_overrides:
       - goos: windows
-        format: zip
+        formats: ["zip"]
     name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
 checksum:


### PR DESCRIPTION
## Summary

Fix GoReleaser deprecation warnings by updating to the new v2.6+ syntax for archive formats.

## Changes

- ✅ Replace `format: tar.gz` with `formats: ["tar.gz"]`
- ✅ Replace `format_overrides.format: zip` with `format_overrides.formats: ["zip"]`

## Problem

The current GoReleaser configuration was generating deprecation warnings:

```
• DEPRECATED: archives.format should not be used anymore
• DEPRECATED: archives.format_overrides.format should not be used anymore
```

## Solution

Updated to the new syntax introduced in GoReleaser v2.6:
- `format` property renamed to `formats`
- Now accepts array of formats instead of single string
- Maintains backward compatibility (single string still accepted)

## Verification

- [x] `make fmt` - passed
- [x] `make lint` - passed  
- [x] Build configuration validated

## References

- [GoReleaser deprecation: archives.format](https://goreleaser.com/deprecations/#archivesformat)
- [GoReleaser deprecation: archives.format_overrides.format](https://goreleaser.com/deprecations/#archivesformat_overridesformat)
