### PR TITLE
docs(readme): add sponsorship support section

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,22 @@ Contributions are welcome! Follow these steps:
 
 See [CLAUDE.md](CLAUDE.md) for detailed development guidelines.
 
+## Support this Project
+
+If you find this project useful, consider sponsoring its development:
+
+- ❤️ [GitHub Sponsors](https://github.com/sponsors/kodflow)
+- ☕ [Ko-fi](https://ko-fi.com/kodflow)
+
+Your support helps:
+
+- ⏰ Dedicate more time to development and maintenance
+- 🐛 Fix bugs faster and implement new features
+- 📚 Improve documentation and examples
+- 🆘 Provide better community support
+
+Every contribution makes a difference! Thank you! 🙏
+
 ## License
 
 Sustainable Use License 1.0


### PR DESCRIPTION
## Summary

Add a dedicated "Support this Project" section in the README to make it easier for users to discover sponsorship options and support the project's development.

## Changes

- ✅ Add "Support this Project" section before License section
- ✅ Include links to GitHub Sponsors and Ko-fi
- ✅ List benefits of sponsoring (development time, bug fixes, docs, support)
- ✅ Clear call-to-action with emojis for visual appeal

## Motivation

With GitHub Sponsors and Ko-fi now active (via PR #10), the README should prominently display these options to:
- Increase visibility of sponsorship opportunities
- Encourage community support
- Explain how contributions help the project
- Make it easy for users to support development

## Type of Change

- [x] 📝 **docs**: Documentation only (no release)

## Checklist

- [x] My code follows the project conventions
- [x] I have performed a self-review of my code
- [x] Code is properly formatted: `make fmt`
- [x] All linters pass: `make lint` (zero errors, zero warnings)
- [x] My PR title follows Conventional Commits: `<type>(<scope>): <description>`

## Tests Performed

```bash
make fmt  # Passed
make lint # Passed
```

## Related Issues

Related to PR #10 (GitHub templates and FUNDING.yml)
