### PR TITLE
fix(registry): correct provider source naming for Terraform Registry

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Before contributing, please:
 
 ```bash
 # Clone the repository
-git clone https://github.com/kodflow/terraform-provider-n8n.git
+git clone https://github.com/kodflow/n8n.git
 cd terraform-provider-n8n
 
 # Install development tools

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -26,7 +26,7 @@ We take the security of the n8n Terraform Provider seriously. If you believe you
 Instead, please report them via one of the following methods:
 
 1. **Email** (Preferred): Send details to `133899878+kodflow@users.noreply.github.com`
-2. **GitHub Security Advisories**: Use the [Security tab](https://github.com/kodflow/terraform-provider-n8n/security/advisories) to report privately
+2. **GitHub Security Advisories**: Use the [Security tab](https://github.com/kodflow/n8n/security/advisories) to report privately
 
 ### What to Include
 
@@ -198,7 +198,7 @@ We appreciate security researchers who responsibly disclose vulnerabilities. Con
 
 ## Questions?
 
-If you have questions about this security policy, please open a discussion in the
-[GitHub Discussions](https://github.com/kodflow/terraform-provider-n8n/discussions) or contact us at `133899878+kodflow@users.noreply.github.com`.
+If you have questions about this security policy, please open a discussion in the [GitHub Discussions](https://github.com/kodflow/n8n/discussions) or contact us
+at `133899878+kodflow@users.noreply.github.com`.
 
 Thank you for helping keep the n8n Terraform Provider secure! 🔒

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,7 +80,7 @@ release:
     terraform {
       required_providers {
         n8n = {
-          source  = "kodflow/terraform-provider-n8n"
+          source  = "kodflow/n8n"
           version = "~> {{ .Version }}"
         }
       }

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ GOARCH := $(shell go env GOARCH)
 LAST_TAG := $(shell git describe --tags --abbrev=0 2>/dev/null || echo "v1.0.0")
 VERSION := $(subst v,,$(LAST_TAG))
 
-PLUGIN_DIR := $(HOME)/.terraform.d/plugins/registry.terraform.io/kodflow/terraform-provider-n8n/$(VERSION)/$(GOOS)_$(GOARCH)
+PLUGIN_DIR := $(HOME)/.terraform.d/plugins/registry.terraform.io/kodflow/n8n/$(VERSION)/$(GOOS)_$(GOARCH)
 
 # Colors for output
 CYAN := \033[36m

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The project includes a fully configured DevContainer with all required tools:
 terraform {
   required_providers {
     n8n = {
-      source  = "kodflow/terraform-provider-n8n"
+      source  = "kodflow/n8n"
       version = "~> 1.0"
     }
   }
@@ -69,7 +69,7 @@ provider "n8n" {
 
 ```bash
 make build
-# Provider installed at: ~/.terraform.d/plugins/registry.terraform.io/kodflow/terraform-provider-n8n/
+# Provider installed at: ~/.terraform.d/plugins/registry.terraform.io/kodflow/n8n/
 ```
 
 ## Quick Start

--- a/examples/basic-sample/main.tf
+++ b/examples/basic-sample/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     n8n = {
-      source  = "kodflow/terraform-provider-n8n"
+      source  = "kodflow/n8n"
       version = "~> 1.0"
     }
   }

--- a/examples/community/credentials/basic-auth/main.tf
+++ b/examples/community/credentials/basic-auth/main.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     n8n = {
-      source  = "kodflow/terraform-provider-n8n"
+      source  = "kodflow/n8n"
       version = "~> 0.1.0"
     }
   }

--- a/examples/community/executions/query-executions/main.tf
+++ b/examples/community/executions/query-executions/main.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     n8n = {
-      source  = "kodflow/terraform-provider-n8n"
+      source  = "kodflow/n8n"
       version = "~> 0.1.0"
     }
   }

--- a/examples/community/main.tf
+++ b/examples/community/main.tf
@@ -4,7 +4,7 @@
 terraform {
   required_providers {
     n8n = {
-      source  = "kodflow/terraform-provider-n8n"
+      source  = "kodflow/n8n"
       version = "~> 1.0"
     }
   }

--- a/examples/community/tags/workflow-tags/main.tf
+++ b/examples/community/tags/workflow-tags/main.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     n8n = {
-      source  = "kodflow/terraform-provider-n8n"
+      source  = "kodflow/n8n"
       version = "~> 0.1.0"
     }
   }

--- a/examples/community/variables/environment-vars/main.tf
+++ b/examples/community/variables/environment-vars/main.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     n8n = {
-      source  = "kodflow/terraform-provider-n8n"
+      source  = "kodflow/n8n"
       version = "~> 0.1.0"
     }
   }

--- a/examples/community/workflows/basic-workflow/main.tf
+++ b/examples/community/workflows/basic-workflow/main.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     n8n = {
-      source  = "kodflow/terraform-provider-n8n"
+      source  = "kodflow/n8n"
       version = "~> 0.1.0"
     }
   }

--- a/examples/community/workflows/scheduled-workflow/main.tf
+++ b/examples/community/workflows/scheduled-workflow/main.tf
@@ -2,7 +2,7 @@
 terraform {
   required_providers {
     n8n = {
-      source  = "kodflow/terraform-provider-n8n"
+      source  = "kodflow/n8n"
       version = "~> 0.1.0"
     }
   }


### PR DESCRIPTION
## Summary

Fix the provider source naming to comply with Terraform Registry standards. This resolves the "invalid provider name" error when publishing to the Terraform Registry.

## Problem

The provider was using an incorrect source name:
```hcl
source = "kodflow/terraform-provider-n8n"  ❌ INCORRECT
```

This caused the Terraform Registry validation error:
```
invalid provider name "terraform-registry-manifest.json"
```

## Solution

According to [Terraform Registry naming conventions](https://developer.hashicorp.com/terraform/registry/providers/publishing#publishing-to-the-registry):

| Element | Format | Example |
|---------|--------|---------|
| **GitHub Repository** | `terraform-provider-{name}` | `kodflow/terraform-provider-n8n` ✅ |
| **Provider Source** | `{namespace}/{name}` | `kodflow/n8n` ✅ |

The `terraform-provider-` prefix is **automatically removed** by Terraform Registry!

## Changes

- ✅ Update `.goreleaser.yml` release header example
- ✅ Update `Makefile` PLUGIN_DIR path
- ✅ Update `README.md` installation instructions
- ✅ Update all example `*.tf` files (9 files)
- ✅ Update `CONTRIBUTING.md` documentation
- ✅ Update `SECURITY.md` examples

**Files changed:** 13 files with consistent provider source updates

## Type of Change

- [x] 🐛 **fix**: Bug fix (patch version)

## Verification

```bash
# Correct usage after this fix:
terraform {
  required_providers {
    n8n = {
      source  = "kodflow/n8n"  # ✅ CORRECT
      version = "~> 1.0"
    }
  }
}
```

## Checklist

- [x] My code follows the project conventions
- [x] I have performed a self-review of my code
- [x] Code is properly formatted: `make fmt`
- [x] All linters pass: `make lint` (zero errors, zero warnings)
- [x] My PR title follows Conventional Commits

## Related Issues

Fixes the Terraform Registry publication error encountered during provider setup.

## References

- [Terraform Registry Provider Publishing](https://developer.hashicorp.com/terraform/registry/providers/publishing)
- [Provider Naming Conventions](https://developer.hashicorp.com/terraform/registry/providers/publishing#publishing-to-the-registry)
