### PR TITLE
fix(docs): correct GitHub repository URLs in documentation

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -45,7 +45,7 @@ Before contributing, please:
 
 ```bash
 # Clone the repository
-git clone https://github.com/kodflow/n8n.git
+git clone https://github.com/kodflow/terraform-provider-n8n.git
 cd terraform-provider-n8n
 
 # Install development tools

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -26,7 +26,7 @@ We take the security of the n8n Terraform Provider seriously. If you believe you
 Instead, please report them via one of the following methods:
 
 1. **Email** (Preferred): Send details to `133899878+kodflow@users.noreply.github.com`
-2. **GitHub Security Advisories**: Use the [Security tab](https://github.com/kodflow/n8n/security/advisories) to report privately
+2. **GitHub Security Advisories**: Use the [Security tab](https://github.com/kodflow/terraform-provider-n8n/security/advisories) to report privately
 
 ### What to Include
 
@@ -198,7 +198,7 @@ We appreciate security researchers who responsibly disclose vulnerabilities. Con
 
 ## Questions?
 
-If you have questions about this security policy, please open a discussion in the [GitHub Discussions](https://github.com/kodflow/n8n/discussions) or contact us
-at `133899878+kodflow@users.noreply.github.com`.
+If you have questions about this security policy, please open a discussion in the
+[GitHub Discussions](https://github.com/kodflow/terraform-provider-n8n/discussions) or contact us at `133899878+kodflow@users.noreply.github.com`.
 
 Thank you for helping keep the n8n Terraform Provider secure! 🔒


### PR DESCRIPTION
## Summary

Fix incorrect GitHub repository URLs that were mistakenly using `kodflow/n8n` instead of `kodflow/terraform-provider-n8n` in documentation files.

## Problem

After the Terraform Registry naming fix (PR #12), we correctly distinguished between:
- **Repository**: `github.com/kodflow/terraform-provider-n8n` (GitHub repo name)
- **Provider source**: `kodflow/n8n` (Terraform Registry identifier)

However, 3 documentation files still incorrectly referenced `github.com/kodflow/n8n` when they should have used the full repository name.

## Changes

### .github/CONTRIBUTING.md
- ❌ **Before**: `git clone https://github.com/kodflow/n8n.git`
- ✅ **After**: `git clone https://github.com/kodflow/terraform-provider-n8n.git`

### .github/SECURITY.md (2 fixes)
- ❌ **Before**: `https://github.com/kodflow/n8n/security/advisories`
- ✅ **After**: `https://github.com/kodflow/terraform-provider-n8n/security/advisories`

- ❌ **Before**: `https://github.com/kodflow/n8n/discussions`
- ✅ **After**: `https://github.com/kodflow/terraform-provider-n8n/discussions`

## Type of Change

- [x] 🐛 **fix**: Bug fix (patch version)

## Verification

```bash
# Before fix:
grep -rn "github.com/kodflow/n8n" .github/
# 3 incorrect URLs found

# After fix:
grep -rn "github.com/kodflow/n8n" .github/
# No output - all URLs corrected ✅
```

## Context

This complements PR #12 which fixed the provider source naming. The naming convention is:

| Context | Format | Example |
|---------|--------|---------|
| **GitHub Repository** | `kodflow/terraform-provider-{name}` | `kodflow/terraform-provider-n8n` ✅ |
| **Provider Source** | `kodflow/{name}` | `kodflow/n8n` ✅ |

## Checklist

- [x] My code follows the project conventions
- [x] I have performed a self-review of my code
- [x] Code is properly formatted: `make fmt`
- [x] All linters pass: `make lint` (zero errors, zero warnings)
- [x] My PR title follows Conventional Commits

## Related Issues

Fixes incorrect GitHub repository URLs discovered after PR #12