### PR TITLE
fix(github): correct provider source in bug report template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -89,7 +89,7 @@ body:
         terraform {
           required_providers {
             n8n = {
-              source  = "kodflow/terraform-provider-n8n"
+              source  = "kodflow/n8n"
               version = "~> 1.0"
             }
           }


### PR DESCRIPTION
## Summary

Correct the Terraform provider source in the bug report issue template. The template contains a Terraform configuration example that should use the correct provider source format.

## Problem

The bug report template at `.github/ISSUE_TEMPLATE/bug_report.yml` contains a placeholder example for Terraform configuration:

```hcl
terraform {
  required_providers {
    n8n = {
      source  = "kodflow/terraform-provider-n8n"  # ❌ INCORRECT
      version = "~> 1.0"
    }
  }
}
```

This is **incorrect** because:
- This is a **Terraform configuration example**
- In Terraform HCL files, the `source` field uses the **provider source format**
- The correct format is `kodflow/n8n` (not the GitHub repository name)

## Changes

### .github/ISSUE_TEMPLATE/bug_report.yml
- ❌ **Before**: `source = "kodflow/terraform-provider-n8n"`
- ✅ **After**: `source = "kodflow/n8n"`

## Context

This template is used when users report bugs. The example should show the **correct Terraform syntax** so users can copy-paste it.

| Context | Format | Example |
|---------|--------|---------|
| **GitHub Repository** | `terraform-provider-{name}` | `kodflow/terraform-provider-n8n` |
| **Provider Source (Terraform)** | `{namespace}/{name}` | `kodflow/n8n` ✅ |

Since this is a **Terraform configuration example** in the template, it must use the **provider source format**: `kodflow/n8n`

## Type of Change

- [x] 🐛 **fix**: Bug fix (patch version)

## Verification

After this fix, users will see the correct example when creating a bug report:

```hcl
terraform {
  required_providers {
    n8n = {
      source  = "kodflow/n8n"  # ✅ CORRECT
      version = "~> 1.0"
    }
  }
}
```

## Checklist

- [x] My code follows the project conventions
- [x] I have performed a self-review of my code
- [x] Code is properly formatted: `make fmt`
- [x] All linters pass: `make lint` (zero errors, zero warnings)
- [x] My PR title follows Conventional Commits

## Related Issues

This fixes the issue template to show the correct Terraform provider source format, ensuring users report bugs with proper configuration examples.