### PR TITLE
feat(codacy): add quality and coverage badges, exclude tests from issues

### DIFF
--- a/.codacy.yml
+++ b/.codacy.yml
@@ -17,6 +17,9 @@ exclude_paths:
   - "**/BUILD.bazel"
   - "**/*.pb.go"
 
+  # Test files (exclude from quality issues, keep for coverage)
+  - "**/*_test.go"
+
   # Standard exclusions
   - "node_modules/**"
   - "vendor/**"
@@ -27,20 +30,3 @@ exclude_paths:
   - ".terraform/**"
   - "*.tfstate"
   - "*.tfstate.backup"
-
-# Engines configuration
-engines:
-  # Go linting and security
-  gosec:
-    enabled: true
-
-  # Security scanning
-  trivy:
-    enabled: true
-    exclude_paths:
-      - ".devcontainer/mcp.json"
-      - "sdk/n8nsdk/**"
-
-  # Go vet
-  govet:
-    enabled: true

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ Terraform provider to manage n8n resources (workflows, credentials, projects, us
 [![Bazel](https://img.shields.io/badge/Build-Bazel%209.0-43A047?logo=bazel)](https://bazel.build/)
 [![Go](https://img.shields.io/badge/Go-1.24-00ADD8?logo=go)](https://go.dev/)
 [![Terraform](https://img.shields.io/badge/Terraform-Plugin%20Framework-7B42BC?logo=terraform)](https://developer.hashicorp.com/terraform/plugin/framework)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/6ad65f0b28b64849ad2799943e8ad338)](https://app.codacy.com/gh/kodflow/terraform-provider-n8n/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/6ad65f0b28b64849ad2799943e8ad338)](https://app.codacy.com/gh/kodflow/terraform-provider-n8n/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 
 ## Features
 


### PR DESCRIPTION
## Summary

Enhance Codacy integration with quality badges and improved analysis configuration.

## Changes

### 1. Added Codacy Badges to README

**Quality Badge:**
[![Codacy Badge](https://app.codacy.com/project/badge/Grade/6ad65f0b28b64849ad2799943e8ad338)](https://app.codacy.com/gh/kodflow/terraform-provider-n8n/dashboard)

**Coverage Badge:**
[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/6ad65f0b28b64849ad2799943e8ad338)](https://app.codacy.com/gh/kodflow/terraform-provider-n8n/dashboard)

### 2. Simplified `.codacy.yml` Configuration

Updated to use global exclusions only, since patterns are configured in Codacy UI.

**Excluded from analysis:**
- `**/*_test.go` - Test files (excluded from quality issues, kept for coverage)
- `sdk/n8nsdk/**` - Generated SDK
- `bazel-*/**` - Bazel build artifacts
- `.devcontainer/mcp.json` - Secrets file

**Benefits:**
- ✅ Simpler configuration file
- ✅ Patterns managed centrally in Codacy UI
- ✅ Test files still included in coverage calculation
- ✅ Reduced noise from test-specific code patterns

### Configuration

```yaml
exclude_paths:
  - ".devcontainer/mcp.json"
  - "sdk/n8nsdk/**"
  - "bazel-*/**"
  - "**/BUILD.bazel"
  - "**/*.pb.go"
  - "**/*_test.go"  # Exclude tests from quality issues
  - "node_modules/**"
  - "vendor/**"
  # ... other standard exclusions
```

## Why Exclude Tests from Issues?

Test files often have patterns that trigger false positives:
- Intentional error cases
- Mock data with hardcoded values
- Test-specific constructs

Excluding them from quality analysis keeps the dashboard focused on production code quality.

## Type of Change

- [x] ✨ **feat**: New feature (minor version)

## Checklist

- [x] My code follows the project conventions
- [x] I have performed a self-review of my code
- [x] Code is properly formatted: `make fmt`
- [x] Documentation updated (README badges)
- [x] Simplified configuration (removed redundant engine specs)