### PR TITLE
docs(readme): add CI, Release and GoDoc badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,12 @@ Terraform provider to manage n8n resources (workflows, credentials, projects, us
 
 [![Bazel](https://img.shields.io/badge/Build-Bazel%209.0-43A047?logo=bazel)](https://bazel.build/)
 [![Go](https://img.shields.io/badge/Go-1.24-00ADD8?logo=go)](https://go.dev/)
-[![Terraform](https://img.shields.io/badge/Terraform-Plugin%20Framework-7B42BC?logo=terraform)](https://developer.hashicorp.com/terraform/plugin/framework)
+[![Terraform Registry](https://img.shields.io/badge/registry-v0.6.0-7B42BC?logo=terraform&label=terraform)](https://registry.terraform.io/providers/kodflow/n8n/latest)
+
+[![CI](https://github.com/kodflow/terraform-provider-n8n/actions/workflows/ci.yml/badge.svg)](https://github.com/kodflow/terraform-provider-n8n/actions/workflows/ci.yml)
+[![GitHub Release](https://img.shields.io/github/v/release/kodflow/terraform-provider-n8n)](https://github.com/kodflow/terraform-provider-n8n/releases)
+[![Go Reference](https://pkg.go.dev/badge/github.com/kodflow/terraform-provider-n8n.svg)](https://pkg.go.dev/github.com/kodflow/terraform-provider-n8n)
+
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/6ad65f0b28b64849ad2799943e8ad338)](https://app.codacy.com/gh/kodflow/terraform-provider-n8n/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 [![Codacy Badge](https://app.codacy.com/project/badge/Coverage/6ad65f0b28b64849ad2799943e8ad338)](https://app.codacy.com/gh/kodflow/terraform-provider-n8n/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 


### PR DESCRIPTION
## Summary

Add comprehensive badge coverage to the README for better project visibility and fix Terraform badge link.

## Badges Added

### 1. GitHub Actions CI
[![CI](https://github.com/kodflow/terraform-provider-n8n/actions/workflows/ci.yml/badge.svg)](https://github.com/kodflow/terraform-provider-n8n/actions/workflows/ci.yml)

Shows real-time CI status for all commits.

### 2. GitHub Release
[![GitHub Release](https://img.shields.io/github/v/release/kodflow/terraform-provider-n8n)](https://github.com/kodflow/terraform-provider-n8n/releases)

Displays the latest published release version.

### 3. Go Reference (pkg.go.dev)
[![Go Reference](https://pkg.go.dev/badge/github.com/kodflow/terraform-provider-n8n.svg)](https://pkg.go.dev/github.com/kodflow/terraform-provider-n8n)

Links to the official Go package documentation.

## Badge Link Fixes

### Terraform Badge
Changed link from framework documentation to Terraform Registry:
- ❌ Before: `https://developer.hashicorp.com/terraform/plugin/framework`
- ✅ After: `https://registry.terraform.io/providers/kodflow/n8n`

Keeps the nice Terraform icon but now points to the actual provider page.

## Badge Organization

Badges are logically grouped in three lines:

**Line 1 - Build Tools:**
- Bazel
- Go
- Terraform Plugin Framework

**Line 2 - CI/CD & Documentation:**
- GitHub Actions CI
- Latest Release
- Go Package Reference

**Line 3 - Code Quality:**
- Codacy Grade
- Codacy Coverage

## Type of Change

- [x] 📝 **docs**: Documentation update

## Checklist

- [x] My code follows the project conventions
- [x] I have performed a self-review of my code
- [x] Code is properly formatted: `make fmt`
- [x] Badges are properly linked and functional
- [x] Terraform badge points to registry instead of framework docs