### PR TITLE
fix(release): correct Terraform Registry manifest configuration

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -65,8 +65,6 @@ release:
   draft: false
   prerelease: auto
   mode: append
-  extra_files:
-    - glob: terraform-registry-manifest.json
   header: |
     ## Terraform Registry Installation
 

--- a/terraform-registry-manifest.json
+++ b/terraform-registry-manifest.json
@@ -1,6 +1,6 @@
 {
   "version": 1,
   "metadata": {
-    "protocol_versions": ["6.0"]
+    "protocol_versions": ["5.0"]
   }
 }


### PR DESCRIPTION
## Summary

Fixes the **"invalid provider name 'terraform-registry-manifest.json'"** error in Terraform Registry releases.

## Changes

### 1. Protocol Version Correction
- Changed `protocol_versions` from `"6.0"` to `"5.0"`
- Aligns with HashiCorp provider standards (AWS, HTTP, Archive, External all use 5.0)
- Compatible with Terraform CLI 0.12+

### 2. GoReleaser Configuration
- **Removed** `terraform-registry-manifest.json` from `extra_files`
- The manifest should exist at repo root but **NOT** be included as a release asset
- Terraform Registry reads it directly from the repository, not from release artifacts

## Root Cause

The error occurred because:
1. GoReleaser was including `terraform-registry-manifest.json` as a release asset
2. Terraform Registry tried to parse this JSON file as a provider binary
3. This caused the "invalid provider name" error

## Verification

After this fix:
- ✅ Manifest file remains at repo root (required by Terraform Registry)
- ✅ Manifest uses correct protocol version (5.0 = Terraform 0.12+)
- ✅ Manifest is NOT uploaded as release asset
- ✅ Only actual provider binaries are in release assets

## References

- [Terraform Provider Publishing](https://developer.hashicorp.com/terraform/registry/providers/publishing)
- [HashiCorp AWS Provider Manifest](https://github.com/hashicorp/terraform-provider-aws/blob/main/terraform-registry-manifest.json)
- Protocol 5.0 = Terraform CLI 0.12+
- Protocol 6.0 = Terraform CLI 1.0+ (newer, but not standard yet)