### PR TITLE
feat(ci): skip release when no source code changes detected

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -60,10 +60,14 @@ jobs:
       - name: Check for source code changes
         id: check_changes
         run: |
-          CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "v0.0.0")
+          CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
           # Check if any files in src/ were modified since last tag
-          if git diff --quiet "$CURRENT_VERSION" HEAD -- src/; then
+          if [ -z "$CURRENT_VERSION" ]; then
+            # No previous tag exists, so this is the first release
+            echo "No previous tag found, treating as first release"
+            echo "has_src_changes=true" >> $GITHUB_OUTPUT
+          elif git diff --quiet "$CURRENT_VERSION" HEAD -- src/; then
             echo "No changes in src/ since $CURRENT_VERSION"
             echo "has_src_changes=false" >> $GITHUB_OUTPUT
           else


### PR DESCRIPTION
## Summary
- Add source code change detection before creating releases
- Skip release when only non-source files are modified
- Prevent unnecessary version bumps for docs/CI/config changes

## Motivation

Currently, every merge to `main` with conventional commit messages triggers a new release, even when only documentation, CI configuration, or other non-source files are modified. This creates unnecessary releases without actual code changes.

## Changes

### Modified `.github/workflows/semver.yml`

Added new step `Check for source code changes` that:
1. Compares current HEAD with the last tag
2. Checks if any files in `src/` directory were modified
3. Sets `has_src_changes` output variable

Updated `Calculate next version` step to:
1. Check if `has_src_changes` is true
2. Skip release creation if no source code changes detected
3. Continue with normal version calculation if changes exist

## Behavior

| Scenario | Previous Behavior | New Behavior |
|----------|-------------------|--------------|
| Changes in `src/` | ✅ Release created | ✅ Release created |
| Changes only in `docs/` | ✅ Release created | ⏭️ Release skipped |
| Changes only in `.github/` | ✅ Release created | ⏭️ Release skipped |
| Changes only in `README.md` | ✅ Release created | ⏭️ Release skipped |
| Changes in `src/` + `docs/` | ✅ Release created | ✅ Release created |

## Testing Checklist

- [ ] Workflow syntax is valid
- [ ] Logic correctly detects src/ changes
- [ ] Skips release when appropriate
- [ ] Creates release when src/ is modified
- [ ] Works with first release (no previous tag)

## Impact

- **Reduced noise**: Fewer unnecessary releases in GitHub
- **Cleaner versioning**: Versions only bump for actual code changes
- **Better semantics**: Release numbers reflect functional changes