### PR TITLE
fix(build): auto-generate n8n nodes registry in make docs

### DIFF
--- a/makefiles/quality.mk
+++ b/makefiles/quality.mk
@@ -49,6 +49,12 @@ docs: ## Generate ALL documentation (Terraform docs + COVERAGE.MD + nodes README
 	@cd src && go mod tidy
 	@printf "  $(CYAN)→$(RESET) Generating Terraform provider documentation\n"
 	@go run github.com/hashicorp/terraform-plugin-docs/cmd/tfplugindocs generate --provider-dir src --provider-name n8n --rendered-website-dir ../docs
+	@printf "  $(CYAN)→$(RESET) Ensuring n8n nodes registry exists\n"
+	@if [ ! -f data/n8n-nodes-registry.json ]; then \
+		echo "  $(YELLOW)⚠$(RESET) Registry not found, generating..."; \
+		bash scripts/nodes/sync-n8n-nodes.sh fetch; \
+		bash scripts/nodes/sync-n8n-nodes.sh parse; \
+	fi
 	@printf "  $(CYAN)→$(RESET) Generating examples/nodes/README.md\n"
 	@chmod +x scripts/nodes/generate-nodes-documentation.js
 	@node scripts/nodes/generate-nodes-documentation.js


### PR DESCRIPTION
## Problem

The CI was failing with:
```
❌ Failed to load registry: ENOENT: no such file or directory, 
open '/home/runner/work/terraform-provider-n8n/terraform-provider-n8n/data/n8n-nodes-registry.json'
```

**Root cause**: `data/n8n-nodes-registry.json` is in `.gitignore` (not committed) but required by `make docs` to generate `examples/nodes/README.md`.

## Solution

Modified `makefiles/quality.mk` to auto-generate the registry if missing:

```bash
@if [ ! -f data/n8n-nodes-registry.json ]; then
  bash scripts/nodes/sync-n8n-nodes.sh fetch
  bash scripts/nodes/sync-n8n-nodes.sh parse
fi
```

## Changes

- ✅ `make docs` now auto-generates missing registry
- ✅ CI can build documentation without manual intervention
- ✅ Local development unaffected (registry cached)

## Testing

Tested by deleting registry and running `make docs`:
```bash
rm -f data/n8n-nodes-registry.json
make docs  # ✅ Success - auto-generated registry
```

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved documentation build process to automatically ensure required data files exist before generation. Missing registry files are now automatically fetched and prepared, making the build process more reliable and reducing manual setup steps.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->