### PR TITLE
fix(build): preserve Go version in update-go-dependencies and add fmt

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -62,6 +62,9 @@ update: ## Update ALL dependencies (Go version + Go deps + n8n SDK + ktn-linter 
 	@$(MAKE) sdk
 	@$(MAKE) docs
 	@echo ""
+	@printf "$(BOLD)Formatting all source files...$(RESET)\n"
+	@$(MAKE) fmt
+	@echo ""
 	@echo "$(BOLD)$(GREEN)✅ All updates completed$(RESET)"
 	@echo ""
 	@echo "$(YELLOW)ℹ$(RESET)  Next steps:"

--- a/scripts/update-go-dependencies.sh
+++ b/scripts/update-go-dependencies.sh
@@ -19,12 +19,24 @@ echo ""
 echo -e "${BOLD}${CYAN}📦 Updating Go dependencies...${RESET}"
 echo ""
 
+# Save current Go version before updating dependencies
+ROOT_GO_VERSION=$(grep -oP 'go \K[0-9]+\.[0-9]+(\.[0-9]+)?' go.mod 2>/dev/null || echo "")
+
 # Update root module dependencies
 echo -e "  ${CYAN}→${RESET} Updating root module dependencies..."
 if go get -u ./... 2>&1; then
   echo -e "  ${GREEN}✓${RESET} Root dependencies updated"
 else
   echo -e "  ${YELLOW}⚠${RESET}  Failed to update root dependencies"
+fi
+
+# Restore Go version if it was changed by go get
+if [ -n "$ROOT_GO_VERSION" ]; then
+  CURRENT_GO_VERSION=$(grep -oP 'go \K[0-9]+\.[0-9]+(\.[0-9]+)?' go.mod 2>/dev/null || echo "")
+  if [ "$CURRENT_GO_VERSION" != "$ROOT_GO_VERSION" ]; then
+    sed -i "s/^go [0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?$/go $ROOT_GO_VERSION/" go.mod
+    echo -e "  ${CYAN}ℹ${RESET}  Restored Go version to $ROOT_GO_VERSION"
+  fi
 fi
 
 echo -e "  ${CYAN}→${RESET} Running go mod tidy on root module..."
@@ -36,11 +48,23 @@ fi
 
 # Update SDK module dependencies
 echo ""
+# Save current Go version before updating SDK dependencies
+SDK_GO_VERSION=$(grep -oP 'go \K[0-9]+\.[0-9]+(\.[0-9]+)?' sdk/n8nsdk/go.mod 2>/dev/null || echo "")
+
 echo -e "  ${CYAN}→${RESET} Updating SDK module dependencies..."
 if (cd sdk/n8nsdk && go get -u ./... 2>&1); then
   echo -e "  ${GREEN}✓${RESET} SDK dependencies updated"
 else
   echo -e "  ${YELLOW}⚠${RESET}  Failed to update SDK dependencies"
+fi
+
+# Restore Go version if it was changed by go get
+if [ -n "$SDK_GO_VERSION" ]; then
+  CURRENT_SDK_GO_VERSION=$(grep -oP 'go \K[0-9]+\.[0-9]+(\.[0-9]+)?' sdk/n8nsdk/go.mod 2>/dev/null || echo "")
+  if [ "$CURRENT_SDK_GO_VERSION" != "$SDK_GO_VERSION" ]; then
+    sed -i "s/^go [0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?$/go $SDK_GO_VERSION/" sdk/n8nsdk/go.mod
+    echo -e "  ${CYAN}ℹ${RESET}  Restored SDK Go version to $SDK_GO_VERSION"
+  fi
 fi
 
 echo -e "  ${CYAN}→${RESET} Running go mod tidy on SDK module..."


### PR DESCRIPTION
## Summary

Fixes two issues in the make update workflow:

1. **Go version regression**: Preserve Go version after go get -u
2. **Missing formatting**: Add make fmt at the end of make update

## Problem

After PR #43, running make update caused Go version to regress:
- update-go-version.sh sets Go 1.25.4
- update-go-dependencies.sh runs go get -u which downgrades to 1.18
- No formatting was applied after updates

## Solution

### Preserve Go version
- Save Go version before running go get -u
- Restore Go version if it was changed
- Apply to both root and SDK modules

### Add formatting
- Run make fmt at the end of make update
- Ensures all code is properly formatted after updates

## Test Plan

- [x] Script saves and restores Go version correctly
- [x] make fmt runs at the end of make update
- [x] Commit GPG signed

## Breaking Changes

None

Fixes regression from #43

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build automation to include automatic source code formatting after regeneration cycles
  * Enhanced dependency update workflow with Go version preservation, maintaining version consistency across project modules during updates

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->