### PR TITLE
refactor(build): simplify Go version management (Option 1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,26 +39,23 @@ include makefiles/terraform.mk
 # ============================================================================
 
 .PHONY: update
-update: ## Update ALL dependencies (Go version + Go deps + n8n SDK + ktn-linter + README badge)
+update: ## Update ALL dependencies (Go deps + n8n SDK + ktn-linter + README badge)
 	@echo ""
 	@echo "$(BOLD)$(CYAN)🔄 Updating all dependencies...$(RESET)"
 	@echo ""
-	@printf "$(BOLD)1/6 Updating Go version to latest stable...$(RESET)\n"
-	@./scripts/update-go-version.sh
-	@echo ""
-	@printf "$(BOLD)2/6 Updating Go dependencies to latest versions...$(RESET)\n"
+	@printf "$(BOLD)1/5 Updating Go dependencies to latest versions...$(RESET)\n"
 	@./scripts/update-go-dependencies.sh
 	@echo ""
-	@printf "$(BOLD)3/6 Updating n8n commit to latest version...$(RESET)\n"
+	@printf "$(BOLD)2/5 Updating n8n commit to latest version...$(RESET)\n"
 	@$(MAKE) sdk/openapi/update
 	@echo ""
-	@printf "$(BOLD)4/6 Updating ktn-linter to latest version...$(RESET)\n"
+	@printf "$(BOLD)3/5 Updating ktn-linter to latest version...$(RESET)\n"
 	@$(MAKE) tools/update
 	@echo ""
-	@printf "$(BOLD)5/6 Updating n8n version badge in README...$(RESET)\n"
+	@printf "$(BOLD)4/5 Updating n8n version badge in README...$(RESET)\n"
 	@./scripts/update-n8n-badge.sh
 	@echo ""
-	@printf "$(BOLD)6/6 Regenerating SDK and documentation...$(RESET)\n"
+	@printf "$(BOLD)5/5 Regenerating SDK and documentation...$(RESET)\n"
 	@$(MAKE) sdk
 	@$(MAKE) docs
 	@echo ""

--- a/scripts/update-go-dependencies.sh
+++ b/scripts/update-go-dependencies.sh
@@ -19,24 +19,12 @@ echo ""
 echo -e "${BOLD}${CYAN}📦 Updating Go dependencies...${RESET}"
 echo ""
 
-# Save current Go version before updating dependencies
-ROOT_GO_VERSION=$(grep -oP 'go \K[0-9]+\.[0-9]+(\.[0-9]+)?' go.mod 2>/dev/null || echo "")
-
 # Update root module dependencies
 echo -e "  ${CYAN}→${RESET} Updating root module dependencies..."
 if go get -u ./... 2>&1; then
   echo -e "  ${GREEN}✓${RESET} Root dependencies updated"
 else
   echo -e "  ${YELLOW}⚠${RESET}  Failed to update root dependencies"
-fi
-
-# Restore Go version if it was changed by go get
-if [ -n "$ROOT_GO_VERSION" ]; then
-  CURRENT_GO_VERSION=$(grep -oP 'go \K[0-9]+\.[0-9]+(\.[0-9]+)?' go.mod 2>/dev/null || echo "")
-  if [ "$CURRENT_GO_VERSION" != "$ROOT_GO_VERSION" ]; then
-    sed -i "s/^go [0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?$/go $ROOT_GO_VERSION/" go.mod
-    echo -e "  ${CYAN}ℹ${RESET}  Restored Go version to $ROOT_GO_VERSION"
-  fi
 fi
 
 echo -e "  ${CYAN}→${RESET} Running go mod tidy on root module..."
@@ -48,23 +36,11 @@ fi
 
 # Update SDK module dependencies
 echo ""
-# Save current Go version before updating SDK dependencies
-SDK_GO_VERSION=$(grep -oP 'go \K[0-9]+\.[0-9]+(\.[0-9]+)?' sdk/n8nsdk/go.mod 2>/dev/null || echo "")
-
 echo -e "  ${CYAN}→${RESET} Updating SDK module dependencies..."
 if (cd sdk/n8nsdk && go get -u ./... 2>&1); then
   echo -e "  ${GREEN}✓${RESET} SDK dependencies updated"
 else
   echo -e "  ${YELLOW}⚠${RESET}  Failed to update SDK dependencies"
-fi
-
-# Restore Go version if it was changed by go get
-if [ -n "$SDK_GO_VERSION" ]; then
-  CURRENT_SDK_GO_VERSION=$(grep -oP 'go \K[0-9]+\.[0-9]+(\.[0-9]+)?' sdk/n8nsdk/go.mod 2>/dev/null || echo "")
-  if [ "$CURRENT_SDK_GO_VERSION" != "$SDK_GO_VERSION" ]; then
-    sed -i "s/^go [0-9]\+\.[0-9]\+\(\.[0-9]\+\)\?$/go $SDK_GO_VERSION/" sdk/n8nsdk/go.mod
-    echo -e "  ${CYAN}ℹ${RESET}  Restored SDK Go version to $SDK_GO_VERSION"
-  fi
 fi
 
 echo -e "  ${CYAN}→${RESET} Running go mod tidy on SDK module..."


### PR DESCRIPTION
## Summary

Simplify Go version management by following Go's recommended practice:
use **minimal version** approach instead of forcing specific versions.

## Changes

### Remove version forcing logic
- Remove all Go version preservation code from update-go-dependencies.sh
- Remove update-go-version.sh from make update workflow
- Let go get -u naturally determine minimal required versions

### How it works now

- `go.mod` specifies the **MINIMAL** Go version required, not the version you use
- SDK stays at Go 1.18 (minimal version compatible with testify)
- Root module has its own minimal version
- You can compile/run with any Go version >= minimal

## Benefits

- Simpler code (27 lines removed)
- Follows Go best practices
- No more version regression issues
- Natural version management by Go toolchain

## Test Plan

- [x] Script simplified and tested
- [x] Makefile updated (5 steps instead of 6)
- [x] Commit GPG signed
- [x] No AI mentions

## Breaking Changes

None - this is purely internal build tooling

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency update automation workflow.
  * Added automatic source code formatting to the build pipeline.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->