### PR TITLE
ci(release): trigger releases on src/ or sdk/ changes

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -62,16 +62,16 @@ jobs:
         run: |
           CURRENT_VERSION=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
 
-          # Check if any files in src/ were modified since last tag
+          # Check if any files in src/ or sdk/ were modified since last tag
           if [ -z "$CURRENT_VERSION" ]; then
             # No previous tag exists, so this is the first release
             echo "No previous tag found, treating as first release"
             echo "has_src_changes=true" >> $GITHUB_OUTPUT
-          elif git diff --quiet "$CURRENT_VERSION" HEAD -- src/; then
-            echo "No changes in src/ since $CURRENT_VERSION"
+          elif git diff --quiet "$CURRENT_VERSION" HEAD -- src/ sdk/; then
+            echo "No changes in src/ or sdk/ since $CURRENT_VERSION"
             echo "has_src_changes=false" >> $GITHUB_OUTPUT
           else
-            echo "Changes detected in src/ since $CURRENT_VERSION"
+            echo "Changes detected in src/ or sdk/ since $CURRENT_VERSION"
             echo "has_src_changes=true" >> $GITHUB_OUTPUT
           fi
 
@@ -83,7 +83,7 @@ jobs:
 
           # Skip release if no source code changes
           if [ "${{ steps.check_changes.outputs.has_src_changes }}" != "true" ]; then
-            echo "⏭️  Skipping release: no changes in src/ directory"
+            echo "⏭️  Skipping release: no changes in src/ or sdk/ directories"
             echo "should_release=false" >> $GITHUB_OUTPUT
             exit 0
           fi

--- a/COVERAGE.MD
+++ b/COVERAGE.MD
@@ -209,5 +209,5 @@ Reading n8n resources without managing their lifecycle.
 
 ---
 
-*Report generated on: 2025-11-20*
+*Report generated on: 2025-11-21*
 *Threshold: 70.0%*


### PR DESCRIPTION
## Summary

Extend automatic release triggering to include SDK changes in addition to provider code changes.

## Problem

Currently, the semver workflow only checks for changes in `src/` directory:
```yaml
elif git diff --quiet "$CURRENT_VERSION" HEAD -- src/; then
```

This means SDK updates (dependency bumps, API changes) don't trigger new releases automatically.

## Solution

Check for changes in **both** `src/` and `sdk/` directories:
```yaml
elif git diff --quiet "$CURRENT_VERSION" HEAD -- src/ sdk/; then
```

## Impact

When SDK changes are pushed to main (like dependency updates or API modifications), the semver workflow will:
1. Detect changes in `sdk/`
2. Calculate next semantic version based on commit messages
3. Create and push a new tag
4. Trigger GoReleaser to build and publish binaries

## Test Plan

- [x] Workflow syntax validated
- [x] Logic updated in both check and skip messages
- [x] Commit GPG signed

## Breaking Changes

None - this only extends the release trigger conditions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release automation to monitor additional directories for source code changes, ensuring accurate version calculation and release detection.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->