### PR TITLE
refactor(ci): rename has_src_changes to has_code_changes

### DIFF
--- a/.github/workflows/semver.yml
+++ b/.github/workflows/semver.yml
@@ -66,13 +66,13 @@ jobs:
           if [ -z "$CURRENT_VERSION" ]; then
             # No previous tag exists, so this is the first release
             echo "No previous tag found, treating as first release"
-            echo "has_src_changes=true" >> $GITHUB_OUTPUT
+            echo "has_code_changes=true" >> $GITHUB_OUTPUT
           elif git diff --quiet "$CURRENT_VERSION" HEAD -- src/ sdk/; then
             echo "No changes in src/ or sdk/ since $CURRENT_VERSION"
-            echo "has_src_changes=false" >> $GITHUB_OUTPUT
+            echo "has_code_changes=false" >> $GITHUB_OUTPUT
           else
             echo "Changes detected in src/ or sdk/ since $CURRENT_VERSION"
-            echo "has_src_changes=true" >> $GITHUB_OUTPUT
+            echo "has_code_changes=true" >> $GITHUB_OUTPUT
           fi
 
       - name: Calculate next version
@@ -82,7 +82,7 @@ jobs:
           NEXT_VERSION=$(svu next || echo "")
 
           # Skip release if no source code changes
-          if [ "${{ steps.check_changes.outputs.has_src_changes }}" != "true" ]; then
+          if [ "${{ steps.check_changes.outputs.has_code_changes }}" != "true" ]; then
             echo "⏭️  Skipping release: no changes in src/ or sdk/ directories"
             echo "should_release=false" >> $GITHUB_OUTPUT
             exit 0


### PR DESCRIPTION
## Summary

Renames the misleading variable `has_src_changes` to `has_code_changes` in the release workflow.

## Changes

- Renamed `has_src_changes` to `has_code_changes` in `.github/workflows/semver.yml`
- Updated all references to use the new variable name

## Rationale

The previous variable name `has_src_changes` was misleading because the check now includes both `src/` and `sdk/` directories (after PR #46). The new name `has_code_changes` better reflects what the variable actually represents.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release workflow configuration to improve release process reliability and clarity.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->