### PR TITLE
fix(ci): use GITHUB_TOKEN for ktn-linter API calls to avoid rate limiting

### DIFF
--- a/makefiles/tools.mk
+++ b/makefiles/tools.mk
@@ -30,7 +30,12 @@ tools/lint: ## Install linting tools
 	@curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s -- -b $$(go env GOPATH)/bin
 	@printf "  $(CYAN)→$(RESET) ktn-linter (latest version)\n"
 	@KTN_ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); \
-	KTN_VERSION=$$(curl -s https://api.github.com/repos/kodflow/ktn-linter/releases/latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/'); \
+	if [ -n "$$GITHUB_TOKEN" ]; then \
+		KTN_VERSION=$$(curl -s -H "Authorization: token $$GITHUB_TOKEN" https://api.github.com/repos/kodflow/ktn-linter/releases/latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/'); \
+	else \
+		KTN_VERSION=$$(curl -s https://api.github.com/repos/kodflow/ktn-linter/releases/latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/'); \
+	fi; \
+	if [ -z "$$KTN_VERSION" ]; then echo "  $(RED)✗$(RESET) Failed to get ktn-linter version from GitHub API"; exit 1; fi; \
 	printf "  $(CYAN)  →$(RESET) Downloading version v$$KTN_VERSION for $$KTN_ARCH\n"; \
 	mkdir -p $$HOME/.local/bin; \
 	curl -fsSL "https://github.com/kodflow/ktn-linter/releases/download/v$${KTN_VERSION}/ktn-linter-linux-$${KTN_ARCH}" -o "$$HOME/.local/bin/ktn-linter" && \
@@ -60,7 +65,12 @@ tools/update: ## Update ktn-linter to latest version
 	@echo ""
 	@echo "$(BOLD)Updating ktn-linter...$(RESET)"
 	@KTN_ARCH=$$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/'); \
-	KTN_VERSION=$$(curl -s https://api.github.com/repos/kodflow/ktn-linter/releases/latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/'); \
+	if [ -n "$$GITHUB_TOKEN" ]; then \
+		KTN_VERSION=$$(curl -s -H "Authorization: token $$GITHUB_TOKEN" https://api.github.com/repos/kodflow/ktn-linter/releases/latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/'); \
+	else \
+		KTN_VERSION=$$(curl -s https://api.github.com/repos/kodflow/ktn-linter/releases/latest | grep '"tag_name"' | sed -E 's/.*"v([^"]+)".*/\1/'); \
+	fi; \
+	if [ -z "$$KTN_VERSION" ]; then echo "  $(RED)✗$(RESET) Failed to get ktn-linter version from GitHub API"; exit 1; fi; \
 	printf "  $(CYAN)→$(RESET) Downloading version v$$KTN_VERSION for $$KTN_ARCH\n"; \
 	mkdir -p $$HOME/.local/bin; \
 	curl -fsSL "https://github.com/kodflow/ktn-linter/releases/download/v$${KTN_VERSION}/ktn-linter-linux-$${KTN_ARCH}" -o "$$HOME/.local/bin/ktn-linter" && \


### PR DESCRIPTION
## Problem

GitHub Actions CI was failing at the "Install tools" step with this error:

```
→ Downloading version v for amd64
curl: (22) The requested URL returned error: 404
```

The ktn-linter installation was trying to download "version v" (empty version string) because the GitHub API rate limit was blocking unauthenticated requests, resulting in an empty response from the API.

## Solution

- Use `GITHUB_TOKEN` environment variable when available (automatically set in GitHub Actions)
- Fall back to unauthenticated requests when running locally
- Add error handling to fail fast if version detection fails
- Apply fix to both `tools/lint` and `tools/update` targets

## Testing

- ✅ Tested locally without `GITHUB_TOKEN` - works correctly
- ✅ Will test in CI with `GITHUB_TOKEN` - should resolve rate limiting

## Related

Fixes the CI failure at https://github.com/kodflow/terraform-provider-n8n/actions/runs/19568879797

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced linting tool resilience with improved error handling for setup and update operations.
  * Added support for authenticated GitHub API requests to optimize version retrieval.
  * Implemented validation checks to ensure version availability before proceeding with installation steps.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->