### PR TITLE
fix(tag,project): use state.ID instead of plan.ID in update operations

### DIFF
--- a/src/internal/provider/project/resource_external_test.go
+++ b/src/internal/provider/project/resource_external_test.go
@@ -610,8 +610,21 @@ func TestProjectResource_Update(t *testing.T) {
 					Raw:    planRaw,
 				}
 
+				// Create valid state (required since Update reads from both plan and state)
+				stateRaw := tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), map[string]tftypes.Value{
+					"id":   tftypes.NewValue(tftypes.String, "proj-123"),
+					"name": tftypes.NewValue(tftypes.String, "existing-project"),
+					"type": tftypes.NewValue(tftypes.String, "team"),
+				})
+
+				state := tfsdk.State{
+					Schema: schemaResp.Schema,
+					Raw:    stateRaw,
+				}
+
 				req := resource.UpdateRequest{
-					Plan: plan,
+					Plan:  plan,
+					State: state,
 				}
 				resp := &resource.UpdateResponse{}
 

--- a/src/internal/provider/project/resource_internal_test.go
+++ b/src/internal/provider/project/resource_internal_test.go
@@ -336,14 +336,17 @@ func TestProjectResource_executeUpdateLogic(t *testing.T) {
 			r := &ProjectResource{client: n8nClient}
 			ctx := context.Background()
 			plan := &models.Resource{
-				ID:   types.StringValue(tt.projectID),
 				Name: types.StringValue(tt.newName),
+			}
+			state := &models.Resource{
+				ID:   types.StringValue(tt.projectID),
+				Name: types.StringValue("Old Name"),
 			}
 			resp := &resource.UpdateResponse{
 				State: resource.UpdateResponse{}.State,
 			}
 
-			result := r.executeUpdateLogic(ctx, plan, resp)
+			result := r.executeUpdateLogic(ctx, plan, state, resp)
 
 			if tt.expectError {
 				assert.False(t, result, "Should return false on error")
@@ -1252,14 +1255,13 @@ func TestProjectResource_executeProjectUpdate(t *testing.T) {
 			r := &ProjectResource{client: n8nClient}
 			ctx := context.Background()
 			plan := &models.Resource{
-				ID:   types.StringValue(tt.projectID),
 				Name: types.StringValue(tt.projectName),
 			}
 			resp := &resource.UpdateResponse{
 				State: resource.UpdateResponse{}.State,
 			}
 
-			result := r.executeProjectUpdate(ctx, plan, resp)
+			result := r.executeProjectUpdate(ctx, tt.projectID, plan, resp)
 
 			if tt.expectError {
 				assert.False(t, result, "Should return false on error")
@@ -1344,14 +1346,11 @@ func TestProjectResource_findProjectAfterUpdate(t *testing.T) {
 
 			r := &ProjectResource{client: n8nClient}
 			ctx := context.Background()
-			plan := &models.Resource{
-				ID: types.StringValue(tt.projectID),
-			}
 			resp := &resource.UpdateResponse{
 				State: resource.UpdateResponse{}.State,
 			}
 
-			result := r.findProjectAfterUpdate(ctx, plan, resp)
+			result := r.findProjectAfterUpdate(ctx, tt.projectID, resp)
 
 			if tt.expectNil {
 				assert.Nil(t, result, "Should return nil")

--- a/src/internal/provider/tag/resource_external_test.go
+++ b/src/internal/provider/tag/resource_external_test.go
@@ -614,8 +614,22 @@ func TestTagResource_Update(t *testing.T) {
 					Raw:    planRaw,
 				}
 
+				// Create valid state (required since Update reads from both plan and state)
+				stateRaw := tftypes.NewValue(schemaResp.Schema.Type().TerraformType(ctx), map[string]tftypes.Value{
+					"id":         tftypes.NewValue(tftypes.String, "tag-123"),
+					"name":       tftypes.NewValue(tftypes.String, "existing-tag"),
+					"created_at": tftypes.NewValue(tftypes.String, "2024-01-01T00:00:00Z"),
+					"updated_at": tftypes.NewValue(tftypes.String, "2024-01-01T00:00:00Z"),
+				})
+
+				state := tfsdk.State{
+					Schema: schemaResp.Schema,
+					Raw:    stateRaw,
+				}
+
 				req := resource.UpdateRequest{
-					Plan: plan,
+					Plan:  plan,
+					State: state,
 				}
 				resp := &resource.UpdateResponse{}
 

--- a/src/internal/provider/tag/resource_internal_test.go
+++ b/src/internal/provider/tag/resource_internal_test.go
@@ -269,14 +269,17 @@ func TestTagResource_executeUpdateLogic(t *testing.T) {
 			r := &TagResource{client: n8nClient}
 			ctx := context.Background()
 			plan := &models.Resource{
-				ID:   types.StringValue(tt.tagID),
 				Name: types.StringValue(tt.newName),
+			}
+			state := &models.Resource{
+				ID:   types.StringValue(tt.tagID),
+				Name: types.StringValue("Old Name"),
 			}
 			resp := &resource.UpdateResponse{
 				State: resource.UpdateResponse{}.State,
 			}
 
-			result := r.executeUpdateLogic(ctx, plan, resp)
+			result := r.executeUpdateLogic(ctx, plan, state, resp)
 
 			if tt.expectError {
 				assert.False(t, result, "Should return false on error")

--- a/src/internal/provider/workflow/resource.go
+++ b/src/internal/provider/workflow/resource.go
@@ -486,8 +486,9 @@ func (r *WorkflowResource) executeUpdateLogic(ctx context.Context, plan, state *
 		return false
 	}
 
-	// Use state.ID for the workflow ID since plan.ID may be Unknown for Computed attributes.
-	// The ID cannot change during an update, so state.ID is always the correct value.
+	// Use state.ID for the workflow ID since plan.ID may be Unknown
+	// for Computed attributes. The ID cannot change during an update,
+	// so state.ID is always the correct value.
 	workflowID := state.ID.ValueString()
 
 	// Copy ID from state to plan for consistency.


### PR DESCRIPTION
## Summary
- Apply the same fix from workflow (PR #57) to tag and project resources
- When updating a resource, plan.ID returns empty string for Computed attributes because the ID is marked as Unknown during plan phase
- This caused 405 Method Not Allowed errors when trying to update tag and project resources
- The fix reads from state.ID which always has the correct value, and copies it to plan.ID for consistency

## Changes
- `tag/resource.go`: Updated `executeUpdateLogic` to receive `state` parameter and use `state.ID`
- `project/resource.go`: Updated `executeUpdateLogic`, `executeProjectUpdate`, and `findProjectAfterUpdate` to use `state.ID`
- `workflow/resource.go`: Fixed inline comment formatting (line too long)
- Updated tests to provide both plan and state parameters

## Test plan
- [x] All unit tests pass (`make test`)
- [x] Linter passes for modified files (`make lint`)
- [x] Code formatted (`make fmt`)

## Related
Fixes the same bug as PR #57 but for tag and project resources.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Update operations now utilize current resource state alongside planned changes for consistent ID handling
  * Post-update verification logic updated to use explicit resource identifiers for resource validation

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->