### PR TITLE
fix(workflow): clear AdditionalProperties in settings normalization

### DIFF
--- a/src/internal/provider/workflow/helpers.go
+++ b/src/internal/provider/workflow/helpers.go
@@ -301,6 +301,11 @@ func normalizeWorkflowSettings(settings n8nsdk.WorkflowSettings) n8nsdk.Workflow
 	if normalized.AvailableInMCP != nil && !*normalized.AvailableInMCP {
 		normalized.AvailableInMCP = nil
 	}
+	
+	// Clear AdditionalProperties to prevent fields returned by the n8n API
+	// (e.g. binaryMode) but rejected on PUT requests from being persisted
+	// in Terraform state, which causes "inconsistent result after apply".
+	normalized.AdditionalProperties = nil
 
 	// Return result.
 	return normalized

--- a/src/internal/provider/workflow/helpers.go
+++ b/src/internal/provider/workflow/helpers.go
@@ -301,7 +301,7 @@ func normalizeWorkflowSettings(settings n8nsdk.WorkflowSettings) n8nsdk.Workflow
 	if normalized.AvailableInMCP != nil && !*normalized.AvailableInMCP {
 		normalized.AvailableInMCP = nil
 	}
-	
+
 	// Clear AdditionalProperties to prevent fields returned by the n8n API
 	// (e.g. binaryMode) but rejected on PUT requests from being persisted
 	// in Terraform state, which causes "inconsistent result after apply".

--- a/src/internal/provider/workflow/helpers.go
+++ b/src/internal/provider/workflow/helpers.go
@@ -279,9 +279,11 @@ func serializeWorkflowJSON(workflow *n8nsdk.Workflow, plan *models.Resource) {
 	}
 }
 
-// normalizeWorkflowSettings removes default values from settings.
-// The n8n API returns default values for certain settings even when not explicitly set.
-// This function removes callerPolicy and availableInMCP defaults to match user config.
+// normalizeWorkflowSettings removes default values and clears undocumented fields from settings.
+// The n8n API returns default values for certain settings even when not explicitly set,
+// as well as undocumented fields (e.g. binaryMode) that are rejected on PUT requests.
+// This function removes callerPolicy and availableInMCP defaults to match user config,
+// and clears AdditionalProperties to prevent "inconsistent result after apply" errors.
 //
 // Params:
 //   - settings: Original workflow settings from API

--- a/src/internal/provider/workflow/helpers_internal_test.go
+++ b/src/internal/provider/workflow/helpers_internal_test.go
@@ -1551,10 +1551,10 @@ func Test_normalizeWorkflowSettings(t *testing.T) {
 			},
 		},
 		{
-			name: "error case - preserves other settings fields untouched",
+			name: "clears AdditionalProperties to prevent undocumented API fields in state",
 			testFunc: func(t *testing.T) {
 				t.Helper()
-				// Test that other fields are preserved.
+				// Test that AdditionalProperties are cleared.
 				settings := n8nsdk.WorkflowSettings{
 					AdditionalProperties: map[string]interface{}{
 						"customField": "value",
@@ -1563,9 +1563,9 @@ func Test_normalizeWorkflowSettings(t *testing.T) {
 
 				result := normalizeWorkflowSettings(settings)
 
-				// Other fields should remain intact.
-				assert.NotNil(t, result.AdditionalProperties)
-				assert.Equal(t, "value", result.AdditionalProperties["customField"])
+				// AdditionalProperties should be cleared to prevent
+				// undocumented API fields from polluting Terraform state.
+				assert.Nil(t, result.AdditionalProperties)
 			},
 		},
 		{


### PR DESCRIPTION
The n8n API returns undocumented fields in workflow settings responses (e.g. binaryMode) that are rejected on PUT requests with "settings must NOT have additional properties". These fields are captured by WorkflowSettings.AdditionalProperties during UnmarshalJSON and persisted in Terraform state, causing "Provider produced inconsistent result after apply" on every update.

This clears AdditionalProperties in normalizeWorkflowSettings before state serialization, since all legitimate settings have dedicated struct fields and any additional property would cause a write failure anyway.

<!-- markdownlint-disable MD041 MD043 -->

## Summary

Clear `AdditionalProperties` in `normalizeWorkflowSettings()` to prevent undocumented API response fields (e.g. `binaryMode`) from polluting Terraform state and causing inconsistent result errors.

## Changes

- [x] Set `normalized.AdditionalProperties = nil` in `normalizeWorkflowSettings()` before returning

## Motivation

The n8n API returns fields like `binaryMode: "separate"` in GET/PUT responses that are not part of the documented settings schema. The SDK's `WorkflowSettings.UnmarshalJSON` captures these into `AdditionalProperties`, which then get serialized into Terraform state via `serializeWorkflowJSON`. Since these fields were never in the planned config, Terraform detects a diff between plan and state, producing `"Provider produced inconsistent result after apply"` on every workflow update. Sending these fields back on PUT results in `400 Bad Request: settings must NOT have additional properties`, creating a deadlock cycle with no user-side workaround.

## Type of Change

- [x] 🐛 **fix**: Bug fix (patch version)

## Checklist

- [x] My code follows the project conventions (CLAUDE.md)
- [x] I have performed a self-review of my code
- [x] I have commented the code in areas that are difficult to understand
- [ ] I have updated the documentation if necessary
- [x] My changes do not generate new warnings
- [ ] I have added tests that prove my fix works or my feature works
- [ ] All tests pass locally: `make test`
- [x] Code is properly formatted: `make fmt`
- [ ] All linters pass: `make lint` (zero errors, zero warnings)
- [x] Build succeeds: `make build`
- [x] My PR title follows Conventional Commits: `<type>(<scope>): <description>`
- [ ] Test coverage is maintained or improved

## Tests Performed

```bash
make fmt
make build
cd sample/ && terraform init && terraform plan

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalization now clears stray additional fields from saved workflow settings so serialized settings written to state no longer include transient or external fields.

* **Tests**
  * Updated unit tests to assert that additional properties are cleared during settings normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->